### PR TITLE
Fixed calculator state after rotation

### DIFF
--- a/financius/src/main/java/com/code44/finance/ui/CalculatorFragment.java
+++ b/financius/src/main/java/com/code44/finance/ui/CalculatorFragment.java
@@ -21,6 +21,7 @@ import javax.inject.Inject;
 public class CalculatorFragment extends BaseFragment implements View.OnClickListener, View.OnLongClickListener {
     private static final String ARG_VALUE = "ARG_VALUE";
     private static final String ARG_RAW_VALUE = "ARG_RAW_VALUE";
+    private static final String ARG_EXPRESSION = "ARG_EXPRESSION";
 
     @Inject Calculator calculator;
 
@@ -117,6 +118,13 @@ public class CalculatorFragment extends BaseFragment implements View.OnClickList
             if (value != 0) {
                 calculator.setValue(value);
             }
+        } else {
+            if (savedInstanceState.containsKey(ARG_EXPRESSION)) {
+                String exp = savedInstanceState.getString(ARG_EXPRESSION, null);
+                if (exp != null) {
+                    calculator.setExpression(exp);
+                }
+            }
         }
 
         updateResult();
@@ -135,6 +143,11 @@ public class CalculatorFragment extends BaseFragment implements View.OnClickList
                 onLayoutFinished();
             }
         });
+    }
+
+    @Override public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putString(ARG_EXPRESSION, calculator.getExpression());
     }
 
     @Override public void onDetach() {

--- a/financius/src/main/java/com/code44/finance/ui/CalculatorFragment.java
+++ b/financius/src/main/java/com/code44/finance/ui/CalculatorFragment.java
@@ -21,7 +21,7 @@ import javax.inject.Inject;
 public class CalculatorFragment extends BaseFragment implements View.OnClickListener, View.OnLongClickListener {
     private static final String ARG_VALUE = "ARG_VALUE";
     private static final String ARG_RAW_VALUE = "ARG_RAW_VALUE";
-    private static final String ARG_EXPRESSION = "ARG_EXPRESSION";
+    private static final String STATE_EXPRESSION = "STATE_EXPRESSION";
 
     @Inject Calculator calculator;
 
@@ -119,8 +119,8 @@ public class CalculatorFragment extends BaseFragment implements View.OnClickList
                 calculator.setValue(value);
             }
         } else {
-            if (savedInstanceState.containsKey(ARG_EXPRESSION)) {
-                String exp = savedInstanceState.getString(ARG_EXPRESSION, null);
+            if (savedInstanceState.containsKey(STATE_EXPRESSION)) {
+                String exp = savedInstanceState.getString(STATE_EXPRESSION, null);
                 if (exp != null) {
                     calculator.setExpression(exp);
                 }
@@ -147,7 +147,7 @@ public class CalculatorFragment extends BaseFragment implements View.OnClickList
 
     @Override public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putString(ARG_EXPRESSION, calculator.getExpression());
+        outState.putString(STATE_EXPRESSION, calculator.getExpression());
     }
 
     @Override public void onDetach() {

--- a/financius/src/main/java/com/code44/finance/utils/Calculator.java
+++ b/financius/src/main/java/com/code44/finance/utils/Calculator.java
@@ -112,6 +112,46 @@ public class Calculator {
         return sb.toString();
     }
 
+    public void setExpression(String expression) {
+        if (expression == null) {
+            throw new IllegalArgumentException("Expression cannot be null");
+        }
+
+        String exps[] = expression.split("");
+
+        for (String part : exps) {
+            boolean isNumber = false;
+
+            try {
+                int num = Integer.valueOf(part);
+                isNumber = true;
+                number(num);
+            } catch (NumberFormatException e) {
+                // Not a number
+            }
+
+            if (!isNumber) {
+                switch (part) {
+                    case DECIMAL:
+                        decimal();
+                        break;
+                    case PLUS:
+                        plus();
+                        break;
+                    case MINUS:
+                        minus();
+                        break;
+                    case MULTIPLY:
+                        multiply();
+                        break;
+                    case DIVIDE:
+                        divide();
+                        break;
+                }
+            }
+        }
+    }
+
     public CharSequence getFormattedExpression() {
         final SpannableStringBuilder ssb = new SpannableStringBuilder();
         for (Part part : parts) {


### PR DESCRIPTION
Fixes #204. Though after rotating screen, numbers without decimals will add `.0` to the back, e.g. `2 x 2.5` will be `2.0 x 2.5`.
