### PR TITLE
Fixed bug with exchange rate in transfer transaction

### DIFF
--- a/financius/src/main/java/com/code44/finance/ui/transactions/edit/TransactionEditActivityPresenter.java
+++ b/financius/src/main/java/com/code44/finance/ui/transactions/edit/TransactionEditActivityPresenter.java
@@ -426,6 +426,10 @@ class TransactionEditActivityPresenter extends ModelEditActivityPresenter<Transa
         isUpdated = true;
         isAutoCompleteUpdateQueued = false;
 
+        if (isAutoComplete && transactionEditData.getStoredTransaction() == null &&
+                transactionEditData.getAccountFrom() != null && transactionEditData.getAccountTo() != null) {
+            transactionEditData.setExchangeRate(currenciesManager.getExchangeRate(transactionEditData.getAccountFrom().getCurrencyCode(), transactionEditData.getAccountTo().getCurrencyCode()));
+        }
         onDataChanged(getStoredModel());
     }
 


### PR DESCRIPTION
That code will fix issue with exchange rate in transfer transaction.
The issue is as follow.
I try to create transfer transaction. If accounts is filled with autocomplete then exchange rate will not load properly( 1 instead of actual value). When I select account manually or when I change field "Amount To" then rate will load correctly.
Steps to reproduce:
1. Create transaction
2. Toggle transaction type to "Transfer"
3. If accounts is filled with autocomplete then exchange rate will be 1

Screenshot from my phone  - 
![screenshot_2015-02-28-20-18-12](https://cloud.githubusercontent.com/assets/1763566/6427893/22c4c840-bf97-11e4-8bdd-521a0e0ce32f.png)
